### PR TITLE
Update Akka dependencies to 2.4.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,12 @@ organization := "io.findify"
 
 scalaVersion := "2.11.8"
 
+val akkaVersion = "2.4.9"
+
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-stream" % "2.4.2",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.4.2",
-  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.2",
+  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+  "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion,
   "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
   "joda-time" % "joda-time" % "2.9.3",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test",


### PR DESCRIPTION
Due to S3Mock using Akka 2.4.9, this conflicts with 2.4.2 preventing the
use of both libraries at the same time. This simply brings the akka
dependency up to 2.4.9.
