### PR TITLE
Fix bug in dequeuing according to a `MaxNumberOfMessages` parameter

### DIFF
--- a/src/main/scala/io/findify/sqsmock/model/QueueCache.scala
+++ b/src/main/scala/io/findify/sqsmock/model/QueueCache.scala
@@ -22,7 +22,7 @@ class QueueCache(params:Queue) {
     msg
   }
   def dequeue(count:Int):List[ReceivedMessage] = {
-    (0 to count).flatMap(_ => dequeue).toList
+    (0 until count).flatMap(_ => dequeue).toList
   }
   def delete(handle:String) = received.get(handle) match {
     case Some(lease) =>

--- a/src/test/scala/io/findify/sqsmock/SendReceiveTest.scala
+++ b/src/test/scala/io/findify/sqsmock/SendReceiveTest.scala
@@ -1,6 +1,7 @@
 package io.findify.sqsmock
 
 import com.amazonaws.services.sqs.AmazonSQSClient
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.collection.JavaConversions._
@@ -24,5 +25,16 @@ class SendReceiveTest extends FlatSpec with Matchers with SQSStartStop {
   it should "detect empty queue" in {
     val result = client.receiveMessage(queue)
     assert(result.getMessages.isEmpty)
+  }
+  it should "dequeue a number of messages according to a `MaxNumberOfMessages` parameter" in {
+    client.sendMessage(queue, "message1")
+    client.sendMessage(queue, "message2")
+    val receiveMessageRequest = new ReceiveMessageRequest(queue).withMaxNumberOfMessages(1)
+    val result1 = client.receiveMessage(receiveMessageRequest)
+    assert(result1.getMessages.size == 1)
+    val result2 = client.receiveMessage(receiveMessageRequest)
+    assert(result2.getMessages.size == 1)
+    val result3 = client.receiveMessage(receiveMessageRequest)
+    assert(result3.getMessages.size == 0)
   }
 }


### PR DESCRIPTION
There's an off-by-one error in the dequeue logic.  Please review.